### PR TITLE
Fix TK6732 - problème création charge entre entité

### DIFF
--- a/class/cronrecurrence.class.php
+++ b/class/cronrecurrence.class.php
@@ -8,12 +8,15 @@ class TCronRecurrence {
 		$this->db = $db;
 	}
 	
-	function run() {	
+	// TODO WARNING si véritable cron : voir methode create_charge_sociale()
+	function run($entity=0) {
 		// Récupération de la liste des charges récurrentes
 		$sql = "
-			SELECT rowid, fk_chargesociale, periode, nb_previsionnel, date_fin
-			FROM " . MAIN_DB_PREFIX . "recurrence
+			SELECT r.rowid, r.fk_chargesociale, r.periode, r.nb_previsionnel, r.date_fin
+			FROM " . MAIN_DB_PREFIX . "recurrence r
 		";
+		
+		if ($entity > 0) $sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'chargesociales cs ON (cs.rowid = r.fk_chargesociale AND cs.entity = '.$entity.')';
 		
 		$res = $this->db->query($sql);
 		
@@ -248,6 +251,7 @@ class TCronRecurrence {
 			$chargesociale->periode = $date;
 			$chargesociale->amount = $obj->amount;
 	
+			// TODO WARNING : si une tache cron fait appel à une routine pour créer les charges, il va y avoir un problème d'entité si multicompany et plusieurs charges sur plusieurs entités
 			$id = $chargesociale->create($user);
 					
 			$chargesociale->add_object_linked('chargesociales', $id_source);

--- a/class/recurrence.class.php
+++ b/class/recurrence.class.php
@@ -48,7 +48,7 @@ class TRecurrence extends TObjetStd {
 	 * Fonction permettant d'ajouter ou modifier une récurrence selon si elle existe ou non
 	 */
 	static function update(&$PDOdb, $id_charge, $periode, $date_fin_rec, $nb_previsionnel, $montant) {
-		global $db;
+		global $db,$conf;
 		
 		if (!empty($date_fin_rec) && !preg_match('/([0-9]{2}[\/-]?){2}([0-9]{4})/', $date_fin_rec))
 			return false;
@@ -76,7 +76,7 @@ class TRecurrence extends TObjetStd {
 		setEventMessage($message);
 		
 		$task = new TCronRecurrence($db);
-		$task->run();
+		$task->run($conf->entity);
 		
 		return true;
 	}

--- a/core/modules/modRecurrence.class.php
+++ b/core/modules/modRecurrence.class.php
@@ -58,7 +58,7 @@ class modRecurrence extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Gestion des récurrences des charges sociales";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0.1';
+		$this->version = '1.0.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
évidemment la requête ne prend pas en compte multicompany et le `create()` d'un objet `ChargeSociales` qui lui set l'entité via une global `$conf`